### PR TITLE
Enable entity synonym mapping for composites

### DIFF
--- a/innatis/extractors/__init__.py
+++ b/innatis/extractors/__init__.py
@@ -1,1 +1,2 @@
 from .composite_entity_extractor import CompositeEntityExtractor
+from .entity_synonyms import EntitySynonymMapper

--- a/innatis/extractors/entity_synonyms.py
+++ b/innatis/extractors/entity_synonyms.py
@@ -1,0 +1,120 @@
+import os
+import warnings
+from typing import Any, Dict, Optional, Text
+
+from rasa_nlu import utils
+from rasa_nlu.config import RasaNLUModelConfig
+from rasa_nlu.extractors import EntityExtractor
+from rasa_nlu.model import Metadata
+from rasa_nlu.training_data import Message, TrainingData
+from rasa_nlu.utils import write_json_to_file
+
+ENTITY_SYNONYMS_FILE_NAME = "entity_synonyms.json"
+
+
+class EntitySynonymMapper(EntityExtractor):
+    name = "ner_synonyms"
+
+    provides = ["entities"]
+
+    def __init__(self,
+                 component_config: Optional[Dict[Text, Text]] = None,
+                 synonyms: Optional[Dict[Text, Any]] = None) -> None:
+
+        super(EntitySynonymMapper, self).__init__(component_config)
+
+        self.synonyms = synonyms if synonyms else {}
+
+    def train(self,
+              training_data: TrainingData,
+              config: RasaNLUModelConfig,
+              **kwargs: Any) -> None:
+
+        for key, value in list(training_data.entity_synonyms.items()):
+            self.add_entities_if_synonyms(key, value)
+
+        for example in training_data.entity_examples:
+            for entity in example.get("entities", []):
+                entity_val = example.text[entity["start"]:entity["end"]]
+                self.add_entities_if_synonyms(entity_val,
+                                              str(entity.get("value")))
+
+    def process(self, message: Message, **kwargs: Any) -> None:
+
+        updated_entities = message.get("entities", [])[:]
+        self.replace_synonyms(updated_entities)
+        message.set("entities", updated_entities, add_to_output=True)
+
+    def persist(self, model_dir: Text) -> Optional[Dict[Text, Any]]:
+
+        if self.synonyms:
+            entity_synonyms_file = os.path.join(model_dir,
+                                                ENTITY_SYNONYMS_FILE_NAME)
+            write_json_to_file(entity_synonyms_file, self.synonyms,
+                               separators=(',', ': '))
+            return {"synonyms_file": ENTITY_SYNONYMS_FILE_NAME}
+        else:
+            return {"synonyms_file": None}
+
+    @classmethod
+    def load(cls,
+             model_dir: Optional[Text] = None,
+             model_metadata: Optional[Metadata] = None,
+             cached_component: Optional['EntitySynonymMapper'] = None,
+             **kwargs: Any
+             ) -> 'EntitySynonymMapper':
+
+        meta = model_metadata.for_component(cls.name)
+        file_name = meta.get("synonyms_file")
+        if not file_name:
+            synonyms = None
+            return cls(meta, synonyms)
+
+        entity_synonyms_file = os.path.join(model_dir, file_name)
+        if os.path.isfile(entity_synonyms_file):
+            synonyms = utils.read_json_file(entity_synonyms_file)
+        else:
+            synonyms = None
+            warnings.warn("Failed to load synonyms file from '{}'"
+                          "".format(entity_synonyms_file))
+        return cls(meta, synonyms)
+
+    def replace_synonyms(self, entities):
+        for entity in entities:
+            # need to wrap in `str` to handle e.g. entity values of type int
+            entity_value = entity["value"]
+            if type (entity_value) is str:
+                entity_value = str(entity_value)
+                if entity_value.lower() in self.synonyms:
+                    entity["value"] = self.synonyms[entity_value.lower()]
+                    self.add_processor_name(entity)
+            if type (entity_value) is dict:
+                # Needed so that we dont add the processors mutiple times
+                add_processor_name = False
+                for key, value in entity_value.items():
+                    value = str(value)
+                    if value.lower() in self.synonyms:
+                        entity["value"][key] = self.synonyms[value.lower()]
+                        add_processor_name = True
+                if add_processor_name :
+                    self.add_processor_name(entity)
+
+    def add_entities_if_synonyms(self, entity_a, entity_b):
+        if entity_b is not None:
+            original = str(entity_a)
+            replacement = str(entity_b)
+
+            if original != replacement:
+                original = original.lower()
+                if (original in self.synonyms and
+                        self.synonyms[original] != replacement):
+                    warnings.warn("Found conflicting synonym definitions "
+                                  "for {}. Overwriting target {} with {}. "
+                                  "Check your training data and remove "
+                                  "conflicting synonym definitions to "
+                                  "prevent this from happening."
+                                  "".format(repr(original),
+                                            repr(self.synonyms[original]),
+                                            repr(replacement)))
+
+                self.synonyms[original] = replacement

--- a/innatis/tests/test_entity_synonyms.py
+++ b/innatis/tests/test_entity_synonyms.py
@@ -1,0 +1,54 @@
+from innatis.extractors import EntitySynonymMapper
+from rasa_nlu.model import Metadata
+import pytest
+
+def test_string_value_entity_synonyms():
+    entities = [{
+        "entity": "test",
+        "value": "chines",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "test",
+        "value": "chinese",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "test",
+        "value": "china",
+        "start": 0,
+        "end": 6
+    }]
+    ent_synonyms = {"chines": "chinese", "NYC": "New York City"}
+    EntitySynonymMapper(synonyms=ent_synonyms).replace_synonyms(entities)
+    assert len(entities) == 3
+    assert entities[0]["value"] == "chinese"
+    assert entities[1]["value"] == "chinese"
+    assert entities[2]["value"] == "china"
+
+
+def test_composites_entity_synonyms():
+    entities = [{
+        "entity": "test",
+        "value": {
+            "food": "egg",
+            "location": "NYC",
+        },
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "test",
+        "value": {
+            "food": "beans",
+            "location": "New York City",
+        },
+        "start": 0,
+        "end": 6
+    }]
+    ent_synonyms = {"egg": "eggs", "nyc": "New York City"}
+    EntitySynonymMapper(synonyms=ent_synonyms).replace_synonyms(entities)
+    assert len(entities) == 2
+    assert entities[0]["value"]["food"] == "eggs"
+    assert entities[0]["value"]["location"] == "New York City"
+    assert entities[1]["value"]["food"] == "beans"
+    assert entities[1]["value"]["location"] == "New York City"

--- a/sample_configs/sample_rasa_innatis_config.yml
+++ b/sample_configs/sample_rasa_innatis_config.yml
@@ -5,6 +5,7 @@ pipeline:
 - name: "tokenizer_spacy"
 - name: "ner_crf"
 - name: "innatis.extractors.CompositeEntityExtractor"
+- name: "innatis.extractors.EntitySynonymMapper"
 - name: "tokenizer_whitespace"
 - name: "intent_featurizer_count_vectors"
 - name: "innatis.featurizers.UniversalSentenceEncoderFeaturizer"


### PR DESCRIPTION
The default entity synonyms mapper does a simple string operation to do its mapping. This in turns makes it not possible for it to transform composites entities since they are dictionaries.
This PR builds on the default to make it able to transform composites
