### PR TITLE
Added fuzzy matching to EntitySynonymMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Viribus Innatis_ means "innate abilities" in Latin. It's a joke...
 
 `$ pip install innatis`
 
-Then add to your pipeline in your `rasa_config.yml`. Example pipeline can be found in [`sample_rasa_innatis_config.yml`](sample_rasa_innatis_config.yml).
+Then add to your pipeline in your `rasa_config.yml`. Example pipeline can be found in [`sample_rasa_innatis_config.yml`](sample_configs/sample_rasa_innatis_config.yml).
 
 ## Components
 
@@ -38,6 +38,7 @@ pipeline:
 ### Extractors
 
 * `composite_entity_extractor` - Given entities extracted by another extractor (`ner_crf` seems to be the best for now), splits them into composite entities, similar to [DialogFlow](https://dialogflow.com/docs/entities/developer-entities#developer_composite).
+* EntitySynonymMapper (replaces `ner_synonyms`) - this is the `ner_synonyms` adapted for `composite_entity_extractor`. You most likely need it if you use `composite_entity_extractor`. It replaces the synonyms with the original entities inside composite entities. It can also do fuzzy matching when matching synonyms (disabled by default). See example config: [`config_composite_entities.yml`](sample_configs/config_composite_entities.yml)
 
 ### Featurizers
 

--- a/innatis/extractors/entity_synonyms.py
+++ b/innatis/extractors/entity_synonyms.py
@@ -1,3 +1,4 @@
+import editdistance
 import os
 import warnings
 from typing import Any, Dict, Optional, Text
@@ -16,6 +17,11 @@ class EntitySynonymMapper(EntityExtractor):
     name = "ner_synonyms"
 
     provides = ["entities"]
+
+    defaults = {
+        "fuzzy_matching": False,
+        "fuzzy_threshold": 0.9
+    }
 
     def __init__(self,
                  component_config: Optional[Dict[Text, Text]] = None,
@@ -81,23 +87,66 @@ class EntitySynonymMapper(EntityExtractor):
 
     def replace_synonyms(self, entities):
         for entity in entities:
-            # need to wrap in `str` to handle e.g. entity values of type int
             entity_value = entity["value"]
-            if type (entity_value) is str:
-                entity_value = str(entity_value)
-                if entity_value.lower() in self.synonyms:
-                    entity["value"] = self.synonyms[entity_value.lower()]
-                    self.add_processor_name(entity)
             if type (entity_value) is dict:
                 # Needed so that we dont add the processors mutiple times
                 add_processor_name = False
                 for key, value in entity_value.items():
-                    value = str(value)
-                    if value.lower() in self.synonyms:
-                        entity["value"][key] = self.synonyms[value.lower()]
+                    lookup_value = str(value).lower()
+                    if lookup_value in self.synonyms:
+                        entity["value"][key] = self.synonyms[lookup_value]
                         add_processor_name = True
-                if add_processor_name :
+                    elif self.component_config["fuzzy_matching"]:
+                        matched = self.fuzzy_match_entity(lookup_value)
+                        if matched:
+                            entity["value"][key] = matched
+                            add_processor_name = True
+                if add_processor_name:
                     self.add_processor_name(entity)
+            else:
+                # need to wrap in `str` to handle e.g. entity values of type int
+                lookup_value = str(entity_value).lower()
+                if lookup_value in self.synonyms:
+                    entity["value"] = self.synonyms[lookup_value]
+                    self.add_processor_name(entity)
+                elif self.component_config["fuzzy_matching"]:
+                    matched = self.fuzzy_match_entity(lookup_value)
+                    if matched:
+                        entity["value"] = matched
+                        self.add_processor_name(entity)
+
+    def fuzzy_match_entity(self, lookup_value):
+        threshold = self.component_config["fuzzy_threshold"]
+        fuzzy_match = None
+
+        # Match the synonyms
+        for synonym in self.synonyms.keys():
+            similarity = EntitySynonymMapper.calc_similarity(synonym, lookup_value)
+            if similarity >= threshold:
+                candidate = (similarity, self.synonyms[synonym])
+                fuzzy_match = max(candidate, fuzzy_match) if fuzzy_match else candidate
+
+        # Match the original values
+        for original_value in set(self.synonyms.values()):
+            similarity = EntitySynonymMapper.calc_similarity(original_value.lower(), lookup_value)
+            if similarity >= threshold:
+                candidate = (similarity, original_value)
+                fuzzy_match = max(candidate, fuzzy_match) if fuzzy_match else candidate
+
+        return fuzzy_match[1] if fuzzy_match else None
+
+    @staticmethod
+    def calc_similarity(str_a, str_b):
+        """
+        Returns a similarity from 0.0 to 1.0 between 2 strings
+
+        This converts the editdistance to a percentage
+        Based on the equation used here:
+        https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher.ratio
+        """
+        distance = editdistance.eval(str_a, str_b)
+        matches = max(len(str_a), len(str_b)) - distance
+        return 2 * matches / (len(str_a) + len(str_b))
 
     def add_entities_if_synonyms(self, entity_a, entity_b):
         if entity_b is not None:

--- a/innatis/tests/test_entity_synonyms.py
+++ b/innatis/tests/test_entity_synonyms.py
@@ -2,53 +2,129 @@ from innatis.extractors import EntitySynonymMapper
 from rasa_nlu.model import Metadata
 import pytest
 
-def test_string_value_entity_synonyms():
+def test_string_value_match():
     entities = [{
-        "entity": "test",
-        "value": "chines",
-        "start": 0,
-        "end": 6
-    }, {
-        "entity": "test",
+        "entity": "cuisine",
         "value": "chinese",
         "start": 0,
         "end": 6
     }, {
-        "entity": "test",
-        "value": "china",
+        "entity": "cuisine",
+        "value": "chineese",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "cuisine",
+        "value": "Italian",
         "start": 0,
         "end": 6
     }]
-    ent_synonyms = {"chines": "chinese", "NYC": "New York City"}
+    ent_synonyms = {"chineese": "chinese", "nyc": "New York City"}
     EntitySynonymMapper(synonyms=ent_synonyms).replace_synonyms(entities)
     assert len(entities) == 3
+    # Does not replace original value
     assert entities[0]["value"] == "chinese"
+    # Replaces synonym with the original value
     assert entities[1]["value"] == "chinese"
-    assert entities[2]["value"] == "china"
+    # Preserves case of non-matched entities
+    assert entities[2]["value"] == "Italian"
 
 
-def test_composites_entity_synonyms():
+def test_composite_entity_match():
     entities = [{
-        "entity": "test",
+        "entity": "restaurant",
         "value": {
-            "food": "egg",
+            "cuisine": "chineese",
             "location": "NYC",
         },
         "start": 0,
         "end": 6
     }, {
-        "entity": "test",
+        "entity": "restaurant",
         "value": {
-            "food": "beans",
+            "cuisine": "Chinese",
             "location": "New York City",
         },
         "start": 0,
         "end": 6
     }]
-    ent_synonyms = {"egg": "eggs", "nyc": "New York City"}
+    ent_synonyms = {"chineese": "chinese", "nyc": "New York City"}
     EntitySynonymMapper(synonyms=ent_synonyms).replace_synonyms(entities)
     assert len(entities) == 2
-    assert entities[0]["value"]["food"] == "eggs"
+    # Replaces synonyms with original values
+    assert entities[0]["value"]["cuisine"] == "chinese"
     assert entities[0]["value"]["location"] == "New York City"
-    assert entities[1]["value"]["food"] == "beans"
+    # Preserves case of non-matched entities; Does not replace original value
+    assert entities[1]["value"]["cuisine"] == "Chinese"
+    assert entities[1]["value"]["location"] == "New York City"
+
+def test_string_value_fuzzy_match():
+    entities = [{
+        "entity": "cuisine",
+        "value": "chinese",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "cuisine",
+        "value": "chinees",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "cuisine",
+        "value": "china",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "location",
+        "value": "NewYork City",
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "cuisine",
+        "value": "Italian",
+        "start": 0,
+        "end": 6
+    }]
+    ent_synonyms = {"chineese": "chinese", "nyc": "New York City"}
+    EntitySynonymMapper({"fuzzy_matching": True}, synonyms=ent_synonyms).replace_synonyms(entities)
+    assert len(entities) == 5
+    # Does not replace original value
+    assert entities[0]["value"] == "chinese"
+    # Replaces fuzzy-matched synonym with original value (chinees -> chineese -> chinese)
+    assert entities[1]["value"] == "chinese"
+    # Does not fuzzy-match if it's too fuzzy (< fuzzy_threshold similarity)
+    assert entities[2]["value"] == "china"
+    # Fuzzy-matches with original value (NewYork City -> New York City)
+    assert entities[3]["value"] == "New York City"
+    # Preserves case of non-matched entities
+    assert entities[4]["value"] == "Italian"
+
+def test_composite_entity_fuzzy_match():
+    entities = [{
+        "entity": "restaurant",
+        "value": {
+            "cuisine": "chinees",
+            "location": "NYC",
+        },
+        "start": 0,
+        "end": 6
+    }, {
+        "entity": "restaurant",
+        "value": {
+            "cuisine": "Italian",
+            "location": "NewYork City",
+        },
+        "start": 0,
+        "end": 6
+    }]
+    ent_synonyms = {"chineese": "chinese", "nyc": "New York City"}
+    EntitySynonymMapper({"fuzzy_matching": True}, synonyms=ent_synonyms).replace_synonyms(entities)
+    assert len(entities) == 2
+    # Replaces fuzzy-matched synonym with original value (chinees -> chineese -> chinese)
+    assert entities[0]["value"]["cuisine"] == "chinese"
+    # Replaces synonym with the original value
+    assert entities[0]["value"]["location"] == "New York City"
+    # Preserves case of non-matched entities
+    assert entities[1]["value"]["cuisine"] == "Italian"
+    # Fuzzy-matches with original value (NewYork City -> New York City)
     assert entities[1]["value"]["location"] == "New York City"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ word2number==1.1
 rasa_nlu==0.14.3
 tensorflow-hub==0.2.0
 spacy==2.0.18
+editdistance==0.5.2

--- a/sample_configs/config_composite_entities.yml
+++ b/sample_configs/config_composite_entities.yml
@@ -10,4 +10,6 @@ pipeline:
   intent_tokenization_flag: true
   intent_split_symbol: "."
 - name: "innatis.extractors.CompositeEntityExtractor"
-
+- name: "innatis.extractors.EntitySynonymMapper"
+  fuzzy_matching: true
+  fuzzy_threshold: 0.9

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,20 @@ install_requires = [
     "rasa_nlu==0.14.3",
     "tensorflow-hub==0.2.0",
     "spacy==2.0.18",
+    "editdistance~=0.5.2",
 ]
 
 setup(
-  name='innatis',
-  install_requires=install_requires,
-  packages=['innatis', 'innatis.classifiers', 'innatis.classifiers.bert', 'innatis.featurizers', 'innatis.extractors'],
-  version='0.5.6',
-  description='A library of useful custom Rasa components',
-  author='CarLabs',
-  author_email='blake@carlabs.com',
-  url='https://github.com/Revmaker/innatis',
-  download_url='https://github.com/Revmaker/innatis/tarball/0.1',
-  keywords=['rasa', 'nlu', 'components'],
-  classifiers=[]
+    name='innatis',
+    install_requires=install_requires,
+    packages=['innatis', 'innatis.classifiers', 'innatis.classifiers.bert',
+              'innatis.featurizers', 'innatis.extractors'],
+    version='0.5.6',
+    description='A library of useful custom Rasa components',
+    author='CarLabs',
+    author_email='blake@carlabs.com',
+    url='https://github.com/Revmaker/innatis',
+    download_url='https://github.com/Revmaker/innatis/tarball/0.1',
+    keywords=['rasa', 'nlu', 'components'],
+    classifiers=[]
 )


### PR DESCRIPTION
Now we can enable fuzzy matching for synonyms with `fuzzy_matching` config and configure similarity threshold with `fuzzy_threshold` from 0.0 - no match to 1.0 - full match.

New dependency:

- editdistance (MIT license)