### PR TITLE
pass explicit session when making predictions

### DIFF
--- a/innatis/classifiers/bert_intent_classifier.py
+++ b/innatis/classifiers/bert_intent_classifier.py
@@ -167,7 +167,7 @@ class BertIntentClassifier(Component):
         probabilities = list(result["probabilities"][0])
 
         with self.session.as_default():
-            index = tf.argmax(probabilities, axis=0).eval()
+            index = tf.argmax(probabilities, axis=0).eval(session=tf.Session())
             label = self.label_list[index]
             score = float(probabilities[index])
 


### PR DESCRIPTION
I got the error when I tried to use a trained model to make predictions:

> Traceback (most recent call last):
  File "rasa_classifier_eval.py", line 61, in <module>
    evaluation_result = list(map(lambda line: interpreter.parse(extract_text(line)), lines))
  File "rasa_classifier_eval.py", line 61, in <lambda>
    evaluation_result = list(map(lambda line: interpreter.parse(extract_text(line)), lines))
  File "/usr/local/lib/python3.6/site-packages/rasa_nlu/model.py", line 357, in parse
    component.process(message, **self.context)
  File "/usr/local/lib/python3.6/site-packages/innatis/classifiers/bert_intent_classifier.py", line 171, in process
    index = tf.argmax(probabilities, axis=0).eval()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 713, in eval
    return _eval_using_default_session(self, feed_dict, self.graph, session)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 5148, in _eval_using_default_session
    raise ValueError("Cannot use the default session to evaluate tensor: "
ValueError: Cannot use the default session to evaluate tensor: the tensor's graph is different from the session's graph. Pass an explicit session to `eval(session=sess)`.

The error is fixed by explicitly pass a session.